### PR TITLE
Make it possible to customize the worker a test is run on.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,20 @@ custom_tests = Dict(
     end
 )
 runtests(ARGS; init_code, custom_tests)
+
+# custom worker
+function test_worker(name)
+    if name == "needs env var"
+        return addworker(env=["SPECIAL_ENV_VAR"=>"42"])
+    end
+    return nothing
+end
+custom_tests = Dict(
+    "needs env var" => quote
+        @test ENV["SPECIAL_ENV_VAR"] == "42"
+    end,
+    "doesn't need env var" => quote
+        @test !haskey(ENV, "SPECIAL_ENV_VAR")
+    end
+)
+runtests(ARGS; test_worker, custom_tests)


### PR DESCRIPTION
In the case of Metal.jl, some tests require specific env vars to be set:

```julia
function test_worker(name)
    if name == "capturing"
        return addworker(env=["METAL_CAPTURE_ENABLED"=>"1"])
    end

    return nothing
end
```