### PR TITLE
don't use Int in TestRecord

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -67,9 +67,9 @@ abstract type AbstractTestRecord end
 struct TestRecord <: AbstractTestRecord
     test::Any
     time::Float64
-    bytes::Int
+    bytes::UInt64
     gctime::Float64
-    rss::UInt
+    rss::UInt64
 end
 
 function memory_usage(rec::TestRecord)


### PR DESCRIPTION
As observed in https://github.com/EnzymeAD/Enzyme.jl/pull/2648

```
Error During Test at none:1
  Got exception outside of a @test
  On worker 2:
  InexactError: trunc(Int32, 2631746420)
  Stacktrace:
    [1] throw_inexacterror
      @ ./boot.jl:634
    [2] checked_trunc_sint
      @ ./boot.jl:656 [inlined]
    [3] toInt32
      @ ./boot.jl:693 [inlined]
    [4] Int32
      @ ./boot.jl:783 [inlined]
    [5] convert
      @ ./number.jl:7 [inlined]
    [6] TestRecord
      @ ~/.julia/packages/ParallelTestRunner/Ensh3/src/ParallelTestRunner.jl:68
    [7] inner
      @ ~/.julia/packages/ParallelTestRunner/Ensh3/src/ParallelTestRunner.jl:181
    [8] runtest
      @ ~/.julia/packages/ParallelTestRunner/Ensh3/src/ParallelTestRunner.jl:195
```
