### PR TITLE
Use IOCapture to silence tests.

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,56 +1,100 @@
 using ParallelTestRunner
-using Test
+using Test, IOCapture
 
-pushfirst!(ARGS, "--verbose")
+@testset "ParallelTestRunner" verbose=true begin
 
-runtests(ARGS)
-
-# custom tests, and initialization code
-init_code = quote
-    using Test
-    should_be_defined() = true
-
-    macro should_also_be_defined()
-        return :(true)
+@testset "basic test" begin
+    println()
+    println("Showing the output of one test run:")
+    println("-"^80)
+    c = IOCapture.capture(passthrough=true) do
+        runtests(["--verbose"])
     end
+    println("-"^80)
+    println()
+    @test contains(c.output, r"basic .+ started at")
+    @test contains(c.output, "SUCCESS")
 end
-custom_tests = Dict(
-    "custom" => quote
-        @test should_be_defined()
-        @test @should_also_be_defined()
-    end
-)
-runtests(ARGS; init_code, custom_tests)
 
-# custom worker
-function test_worker(name)
-    if name == "needs env var"
-        return addworker(env = ["SPECIAL_ENV_VAR" => "42"])
+@testset "custom tests and init code" begin
+    init_code = quote
+        using Test
+        should_be_defined() = true
+
+        macro should_also_be_defined()
+            return :(true)
+        end
     end
-    return nothing
+    custom_tests = Dict(
+        "custom" => quote
+            @test should_be_defined()
+            @test @should_also_be_defined()
+        end
+    )
+    c = IOCapture.capture() do
+        runtests(["--verbose"]; init_code, custom_tests)
+    end
+    @test contains(c.output, r"basic .+ started at")
+    @test contains(c.output, r"custom .+ started at")
+    @test contains(c.output, "SUCCESS")
 end
-custom_tests = Dict(
-    "needs env var" => quote
-        @test ENV["SPECIAL_ENV_VAR"] == "42"
-    end,
-    "doesn't need env var" => quote
-        @test !haskey(ENV, "SPECIAL_ENV_VAR")
-    end
-)
-runtests(ARGS; test_worker, custom_tests)
 
-# failing test
-custom_tests = Dict(
-    "failing test" => quote
-        @test 1 == 2
+@testset "custom worker" begin
+    function test_worker(name)
+        if name == "needs env var"
+            return addworker(env = ["SPECIAL_ENV_VAR" => "42"])
+        end
+        return nothing
     end
-)
-@test_throws Test.FallbackTestSetException("Test run finished with errors") runtests(ARGS; custom_tests)
+    custom_tests = Dict(
+        "needs env var" => quote
+            @test ENV["SPECIAL_ENV_VAR"] == "42"
+        end,
+        "doesn't need env var" => quote
+            @test !haskey(ENV, "SPECIAL_ENV_VAR")
+        end
+    )
+    c = IOCapture.capture() do
+        runtests(["--verbose"]; test_worker, custom_tests)
+    end
+    @test contains(c.output, r"basic .+ started at")
+    @test contains(c.output, r"needs env var .+ started at")
+    @test contains(c.output, r"doesn't need env var .+ started at")
+    @test contains(c.output, "SUCCESS")
+end
 
-# throwing test
-custom_tests = Dict(
-    "throwing test" => quote
-        error("This test throws an error")
+@testset "failing test" begin
+    custom_tests = Dict(
+        "failing test" => quote
+            @test 1 == 2
+        end
+    )
+    c = IOCapture.capture(rethrow=Union{}) do
+        runtests(["--verbose"]; custom_tests)
     end
-)
-@test_throws Test.FallbackTestSetException("Test run finished with errors") runtests(ARGS; custom_tests)
+    @test contains(c.output, r"basic .+ started at")
+    @test contains(c.output, r"failing test .+ failed at")
+    @test contains(c.output, "FAILURE")
+    @test contains(c.output, "1 == 2")
+    @test c.error
+    @test c.value == Test.FallbackTestSetException("Test run finished with errors")
+end
+
+@testset "throwing test" begin
+    custom_tests = Dict(
+        "throwing test" => quote
+            error("This test throws an error")
+        end
+    )
+    c = IOCapture.capture(rethrow=Union{}) do
+        runtests(["--verbose"]; custom_tests)
+    end
+    @test contains(c.output, r"basic .+ started at")
+    @test contains(c.output, r"throwing test .+ failed at")
+    @test contains(c.output, "FAILURE")
+    @test contains(c.output, "Got exception outside of a @test")
+    @test c.error
+    @test c.value == Test.FallbackTestSetException("Test run finished with errors")
+end
+
+end


### PR DESCRIPTION
The test output of this package is now simply:

```
     Testing Running tests...

Showing the output of one test run:
--------------------------------------------------------------------------------
[ Info: Running 1 tests in parallel. If this is too many, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.
               |          | ---------------- CPU ---------------- |
Test  (Worker) | Time (s) |  GC (s) | GC % | Alloc (MB) | RSS (MB) |
basic      (2) |        started at 2025-10-12T08:58:41.233
basic      (2) |     0.03 |   0.00 |  0.0 |       2.13 |   373.42 |

Test Summary: | Pass  Total  Time
  Overall     |    1      1  2.3s
    SUCCESS
--------------------------------------------------------------------------------

Test Summary:                | Pass  Total   Time
ParallelTestRunner           |   21     21  37.8s
  basic test                 |    2      2   8.7s
  custom tests and init code |    3      3   5.1s
  custom worker              |    4      4  10.2s
  failing test               |    6      6   7.4s
  throwing test              |    6      6   6.4s
     Testing ParallelTestRunner tests passed 
```