### PR TITLE
Fix `clear_status`

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -591,8 +591,8 @@ function runtests(mod::Module, ARGS; test_filter = Returns(true), RecordType = T
     function clear_status()
         if status_lines_visible[] > 0
             for i in 1:status_lines_visible[]-1
-                print(io_ctx.stdout, "\033[1A")  # Move up one line
                 print(io_ctx.stdout, "\033[2K")  # Clear entire line
+                print(io_ctx.stdout, "\033[1A")  # Move up one line
             end
             print(io_ctx.stdout, "\r")  # Move to start of line
             status_lines_visible[] = 0


### PR DESCRIPTION
Probably missed because when there's a broken, failing, or erroring test this bug is hidden. 

Before (bug is on Test Summary line):
```
                                 │          │ ──────────────── CPU ──────────────── │
Test                    (Worker) │ Time (s) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
device/intrinsics/arguments  (3) │    14.06 │   0.33 │  2.4 │    2553.03 │   804.14 │
device/intrinsics/atomics    (2) │    20.33 │   0.44 │  2.2 │    4131.85 │   846.61 │

Test Summary: | Pass  Total   TimeA: ~0 min
  Overall     |  118    118  26.4s
    SUCCESS
     Testing Metal tests passed
```

This PR:
```
                                 │          │ ──────────────── CPU ──────────────── │
Test                    (Worker) │ Time (s) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
device/intrinsics/arguments  (3) │    14.03 │   0.33 │  2.3 │    2552.47 │   806.64 │
device/intrinsics/atomics    (2) │    20.65 │   0.46 │  2.2 │    4132.25 │   852.47 │

Test Summary: | Pass  Total   Time
  Overall     |  118    118  27.4s
    SUCCESS
     Testing Metal tests passed
```

Includes a bonus unused variable cleanup.