### PR TITLE
Update macOS `available_memory` to match libuv version

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -286,7 +286,7 @@ function available_memory()
 
 	page_size = Int(@ccall sysconf(29::UInt32)::UInt32)
 
-	return (Int(vms[].free_count) + Int(vms[].inactive_count)) * page_size
+	return (Int(vms[].free_count) + Int(vms[].inactive_count) + Int(vms[].purgeable_count)) * page_size
 end
 
 else


### PR DESCRIPTION
It was suggested to me in https://github.com/libuv/libuv/pull/4908 to include `purgeable_count` in the available memory calculation.

Maybe this'll allow the 8GB mac mini runners to always have at least 2 runners and sometimes 3.