### PR TITLE
[CI] Add a job timeout

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -32,6 +32,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is to prevents jobs such as https://github.com/JuliaTesting/ParallelTestRunner.jl/actions/runs/18715313948/job/53373152654 from hanging for 6 hours