### PR TITLE
Define environment variable for overriding number of jobs

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -360,7 +360,9 @@ Determine default number of parallel jobs.
 function default_njobs(; cpu_threads = Sys.CPU_THREADS, free_memory = available_memory())
     jobs = cpu_threads
     memory_jobs = Int64(free_memory) ÷ (2 * 2^30)
-    return max(1, min(jobs, memory_jobs))
+    env_var_num_jobs = tryparse(Int, get(ENV, "PARALLELTESTRUNNER_NUM_JOBS", ""))
+    # `PARALLELTESTRUNNER_NUM_JOBS` would take precedence over the default calculation.
+    return something(env_var_num_jobs, max(1, min(jobs, memory_jobs)))
 end
 
 # Historical test duration database

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,4 +223,11 @@ end
     @test contains(str, "SUCCESS")
 end
 
+@testset "Number of jobs" begin
+    num_jobs = 1234
+    withenv("PARALLELTESTRUNNER_NUM_JOBS" => num_jobs) do
+        @test ParallelTestRunner.default_njobs() == num_jobs
+    end
+end
+
 end


### PR DESCRIPTION
I'm happy to discuss alternative solutions, I'm not married to this one in particular, but the problem I want to solve is to be able to spawn _more_ jobs than what `default_njobs` would do.  Setting `JULIA_CPU_THREADS` only affects https://github.com/JuliaTesting/ParallelTestRunner.jl/blob/c79f4cc7a42d6bc4631e90629dafac546f2536bc/src/ParallelTestRunner.jl#L361-L363 but that doesn't help anything, because the limitation is usually `memory_jobs`.  Perhaps an alternative solution is to be able to control the expected memory usage more easily, which at the moment is impossible.

The only thing I like of using an environment variable to override the number of jobs is that that's easy to set in CI jobs, my main use case would be to have at least 2 parallel jobs on Apple Silicon macOS on GitHub-hosted runners, because at the moment we always get only one ([3 CPUs and 7 GB of memory](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)), which is a waste for most jobs.