### PR TITLE
Clarify description of command line args argument to `runtests`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -41,6 +41,10 @@ default_njobs
 
 ## Internal Types
 
+These are internal types, not subject to semantic versioning contract (could be changed or removed at any point without notice), not intended for consumption by end-users.
+They are documented here exclusively for `ParallelTestRunner` developers and contributors.
+
 ```@docs
+ParsedArgs
 WorkerTestSet
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -81,7 +81,7 @@ julia --project test/runtests.jl --quickfail
 
 ### Using with Pkg.test
 
-You can also pass arguments through `Pkg.test`:
+You can also pass arguments through [`Pkg.test`](https://pkgdocs.julialang.org/v1/api/#Pkg.test):
 
 ```julia
 using Pkg


### PR DESCRIPTION
The current docstring had conflicting information: the signature showed only `ParsedArgs` was accepted, but the description suggested only a vector of strings (like `Base.ARGS`) was accepted.