### PR TITLE
Allow IOCapture v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Dates = "1"
-IOCapture = "0.2.5"
+IOCapture = "0.2.5, 1"
 Malt = "1.3.0"
 Printf = "1"
 Random = "1"


### PR DESCRIPTION
They report no breaking changes from 0.2.5, see [the release notes](https://github.com/JuliaDocs/IOCapture.jl/releases)