### PR TITLE
[docs] Add `runtests` call in mock package

### DIFF
--- a/docs/MyPackage/test/runtests.jl
+++ b/docs/MyPackage/test/runtests.jl
@@ -1,2 +1,4 @@
 using MyPackage
 using ParallelTestRunner
+
+runtests(MyPackage, ARGS)


### PR DESCRIPTION
Because the call to `runtests` was missing, the tests in the section about interactive use were not actually run at all.