### PR TITLE
Display pre-test time

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -108,7 +108,7 @@ struct TestIOContext
     stdout::IO
     stderr::IO
     color::Bool
-    debug_stats::Bool
+    verbose::Bool
     lock::ReentrantLock
     name_align::Int
     elapsed_align::Int
@@ -119,7 +119,7 @@ struct TestIOContext
     rss_align::Int
 end
 
-function test_IOContext(stdout::IO, stderr::IO, lock::ReentrantLock, name_align::Int, debug_stats::Bool)
+function test_IOContext(stdout::IO, stderr::IO, lock::ReentrantLock, name_align::Int, verbose::Bool)
     elapsed_align = textwidth("time (s)")
     compile_align = textwidth("Compile")
     gc_align = textwidth("GC (s)")
@@ -130,7 +130,7 @@ function test_IOContext(stdout::IO, stderr::IO, lock::ReentrantLock, name_align:
     color = get(stdout, :color, false)
 
     return TestIOContext(
-        stdout, stderr, color, debug_stats, lock, name_align, elapsed_align, compile_align, gc_align, percent_align,
+        stdout, stderr, color, verbose, lock, name_align, elapsed_align, compile_align, gc_align, percent_align,
         alloc_align, rss_align
     )
 end
@@ -141,16 +141,16 @@ function print_header(ctx::TestIOContext, testgroupheader, workerheader)
         # header top
         printstyled(ctx.stdout, " "^(ctx.name_align + textwidth(testgroupheader) - 3), " │ ")
         printstyled(ctx.stdout, "  Test   │", color = :white)
-        ctx.debug_stats && printstyled(ctx.stdout, "   Init   │", color = :white)
-        VERSION >= v"1.11" && ctx.debug_stats && printstyled(ctx.stdout, " Compile │", color = :white)
+        ctx.verbose && printstyled(ctx.stdout, "   Init   │", color = :white)
+        VERSION >= v"1.11" && ctx.verbose && printstyled(ctx.stdout, " Compile │", color = :white)
         printstyled(ctx.stdout, " ──────────────── CPU ──────────────── │\n", color = :white)
 
         # header bottom
         printstyled(ctx.stdout, testgroupheader, color = :white)
         printstyled(ctx.stdout, lpad(workerheader, ctx.name_align - textwidth(testgroupheader) + 1), " │ ", color = :white)
         printstyled(ctx.stdout, "time (s) │", color = :white)
-        ctx.debug_stats && printstyled(ctx.stdout, " time (s) │", color = :white)
-        VERSION >= v"1.11" && ctx.debug_stats && printstyled(ctx.stdout, "   (%)   │", color = :white)
+        ctx.verbose && printstyled(ctx.stdout, " time (s) │", color = :white)
+        VERSION >= v"1.11" && ctx.verbose && printstyled(ctx.stdout, "   (%)   │", color = :white)
         printstyled(ctx.stdout, " GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │\n", color = :white)
         flush(ctx.stdout)
     finally
@@ -181,7 +181,7 @@ function print_test_finished(record::TestRecord, wrkr, test, ctx::TestIOContext)
         time_str = @sprintf("%7.2f", record.time)
         printstyled(ctx.stdout, lpad(time_str, ctx.elapsed_align, " "), " │ ", color = :white)
 
-        if ctx.debug_stats
+        if ctx.verbose
             # pre-testset time
             init_time_str = @sprintf("%7.2f", record.total_time - record.time)
             printstyled(ctx.stdout, lpad(init_time_str, ctx.elapsed_align, " "), " │ ", color = :white)
@@ -222,7 +222,7 @@ function print_test_failed(record::TestRecord, wrkr, test, ctx::TestIOContext)
         time_str = @sprintf("%7.2f", record.time)
         printstyled(ctx.stderr, lpad(time_str, ctx.elapsed_align + 1, " "), " │", color = :red)
 
-        if ctx.debug_stats
+        if ctx.verbose
             init_time_str = @sprintf("%7.2f", record.total_time - record.time)
             printstyled(ctx.stdout, lpad(init_time_str, ctx.elapsed_align + 1, " "), " │ ", color = :red)
         end
@@ -571,7 +571,6 @@ Fields are
 
 * `jobs::Union{Some{Int}, Nothing}`: the number of jobs
 * `verbose::Union{Some{Nothing}, Nothing}`: whether verbose printing was enabled
-* `debug_stats::Union{Some{Nothing}, Nothing}`: whether debug stats printing was enabled
 * `quickfail::Union{Some{Nothing}, Nothing}`: whether quick fail was enabled
 * `list::Union{Some{Nothing}, Nothing}`: whether tests should be listed
 * `custom::Dict{String,Any}`: a dictionary of custom arguments
@@ -580,7 +579,6 @@ Fields are
 struct ParsedArgs
     jobs::Union{Some{Int}, Nothing}
     verbose::Union{Some{Nothing}, Nothing}
-    debug_stats::Union{Some{Nothing}, Nothing}
     quickfail::Union{Some{Nothing}, Nothing}
     list::Union{Some{Nothing}, Nothing}
 
@@ -638,8 +636,7 @@ function parse_args(args; custom::Array{String} = String[])
                --list             List all available tests.
                --verbose          Print more information during testing.
                --quickfail        Fail the entire run as soon as a single test errored.
-               --jobs=N           Launch `N` processes to perform tests.
-               --debug-stats      Print information that could be helpful for debugging testset slowdowns."""
+               --jobs=N           Launch `N` processes to perform tests."""
 
         if !isempty(custom)
             usage *= "\n\nCustom arguments:"
@@ -654,7 +651,6 @@ function parse_args(args; custom::Array{String} = String[])
 
     jobs = extract_flag!(args, "--jobs"; typ = Int)
     verbose = extract_flag!(args, "--verbose")
-    debug_stats = extract_flag!(args, "--debug-stats")
     quickfail = extract_flag!(args, "--quickfail")
     list = extract_flag!(args, "--list")
 
@@ -669,7 +665,7 @@ function parse_args(args; custom::Array{String} = String[])
         error("Unknown test options `$(join(optlike_args, " "))` (try `--help` for usage instructions)")
     end
 
-    return ParsedArgs(jobs, verbose, debug_stats, quickfail, list, custom_args, args)
+    return ParsedArgs(jobs, verbose, quickfail, list, custom_args, args)
 end
 
 """
@@ -829,7 +825,7 @@ function runtests(mod::Module, args::ParsedArgs;
     jobs = something(args.jobs, default_njobs())
     jobs = clamp(jobs, 1, length(tests))
     println(stdout, "Running $(length(tests)) tests using $jobs parallel jobs. If this is too many concurrent jobs, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.")
-    !isnothing(args.debug_stats) && println(stdout, "Available memory: $(Base.format_bytes(available_memory()))")
+    !isnothing(args.verbose) && println(stdout, "Available memory: $(Base.format_bytes(available_memory()))")
     workers = fill(nothing, jobs)
 
     t0 = time()
@@ -871,7 +867,7 @@ function runtests(mod::Module, args::ParsedArgs;
         stderr.lock = print_lock
     end
 
-    io_ctx = test_IOContext(stdout, stderr, print_lock, name_align, !isnothing(args.debug_stats))
+    io_ctx = test_IOContext(stdout, stderr, print_lock, name_align, !isnothing(args.verbose))
     print_header(io_ctx, testgroupheader, workerheader)
 
     status_lines_visible = Ref(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,17 +20,10 @@ include(joinpath(@__DIR__, "utils.jl"))
     println("-"^80)
     println()
 
-    @test contains(str, r"basic .+ started at")
     @test contains(str, "SUCCESS")
 
-    @test isfile(ParallelTestRunner.get_history_file(ParallelTestRunner))
-end
-
-@testset "debug timing" begin
-    io = IOBuffer()
-    io_color = IOContext(io, :color => true)
-    runtests(ParallelTestRunner, ["--debug-stats"]; stdout=io_color, stderr=io_color)
-    str = String(take!(io))
+    # --verbose output
+    @test contains(str, r"basic .+ started at")
 
     @test contains(str, "time (s)")
 
@@ -42,6 +35,8 @@ end
         @test contains(str, "Compile")
         @test contains(str, "(%)")
     end
+
+    @test isfile(ParallelTestRunner.get_history_file(ParallelTestRunner))
 end
 
 @testset "default njobs" begin


### PR DESCRIPTION
Adds `--debug-stats` flag. This adds a printout of available memory as used by PTR to make runner # decisions before tests, a column that displays how long it took between worker running and testset starting, and on 1.11+, % of time spent in Julia precompilation.

Example:
```julia-repl
julia> Pkg.test("Metal"; test_args=`--debug-stats --jobs=1 mtl`)
...
<Stuff>
...
Running 1 tests in parallel. If this is too many, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.
Available memory: 24.014 GiB
                │   Test   │   Init   │ Compile │ ──────────────── CPU ──────────────── │
Test   (Worker) │ time (s) │ time (s) │   (%)   │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
mtl/metal   (1) │     4.62 │     6.17 │   88.00 │   0.18 │  3.9 │     779.42 │   952.48 │
mtl/size    (1) │     0.06 │     0.21 │   72.99 │   0.00 │  0.0 │       3.12 │   954.42 │

Test Summary: | Pass  Total   Time
  Overall     |  221    221  13.2s
    SUCCESS
     Testing Metal tests passed
```

Close #99