### PR TITLE
macOS: Also consider compressed pages as usable.

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -368,7 +368,7 @@ function available_memory()
 
 	page_size = Int(@ccall sysconf(29::UInt32)::UInt32)
 
-	return (Int(vms[].free_count) + Int(vms[].inactive_count) + Int(vms[].purgeable_count)) * page_size
+	return (Int(vms[].free_count) + Int(vms[].inactive_count) + Int(vms[].purgeable_count) + Int(vms[].compressor_page_count)) * page_size
 end
 
 else


### PR DESCRIPTION
I noticed that on my system ParallelTestRunner only ever used a single worker. This because my memory usage is:
- Total memory: 18GiB
- Used: 16GiB
  - Apps: 5.5GiB
  - Wired: 3.5GiB
  - Compressed: 7GiB
- Cached: 2GiB
- Swap: 7.5GiB

So only taking free + inactive + purgeable into account gives us 2.8G, only enough for a single worker, while adding the compressed pages brings it to 10G allowing 5 workers. AFAIU these compressed pages should be safe to ignore, as they can be swapped out. I verified here that given a 10GiB computation I can allocate a 10GiB array without killing my system (although it was a bit angry while swapping out the compressed pages).

cc @christiangnrd 