### PR TITLE
[docs] add MathOptInterface.jl to the list of packages

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -153,6 +153,7 @@ Among them are:
 * [`GPUArrays.jl`](https://github.com/JuliaGPU/GPUArrays.jl/blob/master/test/runtests.jl)
 * [`GPUCompiler.jl`](https://github.com/JuliaGPU/GPUCompiler.jl/blob/master/test/runtests.jl)
 * [`HyperHessians.jl`](https://github.com/KristofferC/HyperHessians.jl/blob/master/test/runtests.jl)
+* [`MathOptInterface.jl`](https://github.com/jump-dev/MathOptInterface.jl/blob/master/test/runtests.jl)
 * [`Metal.jl`](https://github.com/JuliaGPU/Metal.jl/blob/main/test/runtests.jl)
 * [`Reactant.jl`](https://github.com/EnzymeAD/Reactant.jl/blob/main/test/runtests.jl)
 * [`WCS.jl`](https://github.com/JuliaAstro/WCS.jl/blob/master/test/runtests.jl)


### PR DESCRIPTION
Hey! 

I started using this in https://github.com/jump-dev/MathOptInterface.jl

Some may find our workflow interesting.

There are a lot of tests in MOI, and it is almost entirely bottlenecked by compilation time. (I should probably experiment with `Base.Experimental.@optlevel`.)

We shard the tests into directories in `/test`, and then use `ParallelTestRunner` to parallelise over the files in each directory. 

Each file is a module that automatically detects and runs all of the functions named `test_`.

I find this works much better than `@testset`, where I kept leaking stuff into setup and global scope and it was hard to maintain.

Now adding a test is: choose a file, add a function.

You can improve parallelisation by [splitting tests into a new file](https://github.com/jump-dev/MathOptInterface.jl/blob/master/test/Utilities/test_model_runtests.jl)

The biggest downside is that it's easy to add two functions with the same name that overwrite each other. So there's a test to avoid that:
https://github.com/jump-dev/MathOptInterface.jl/blob/ea3cf8ca0060d776bb351fe4f7e1698d308f105c/test/General/test_errors.jl#L430-L453