### PR TITLE
Restore the working project after running user code.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
+version = "2.4.1"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.4.0"
+
+[workspace]
+projects = ["test"]
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,7 @@
 [deps]
+ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+ParallelTestRunner = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -373,4 +373,25 @@ end
     @test contains(str, "SUCCESS")
 end
 
+@testset "switching projects" begin
+    testsuite = Dict(
+        "first" => quote
+            using Pkg
+            Pkg.activate(; temp=true)
+            @test 1 + 1 == 2
+        end,
+        "second" => quote
+            @test 2 * 2 == 4
+        end
+    )
+
+    io = IOBuffer()
+    runtests(ParallelTestRunner, ["--verbose", "--jobs=1"]; testsuite, stdout=io, stderr=io)
+
+    str = String(take!(io))
+    @test contains(str, r"first .+ started at")
+    @test contains(str, r"second .+ started at")
+    @test contains(str, "SUCCESS")
+end
+
 end


### PR DESCRIPTION
Otherwise the runner is broken after a test switches projects:

```julia
using ParallelTestRunner
using Test

testsuite = Dict(
    "first test" => quote
        using Pkg
        Pkg.activate(; temp=true)
        @test 1 + 1 == 2
    end,
    "second test" => quote
        @test 2 * 2 == 4
    end
)

runtests(ParallelTestRunner, ["--verbose", "--jobs=1"]; testsuite)
```

```
                  │          │ ──────────────── CPU ──────────────── │
Test     (Worker) │ Time (s) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
first test    (1) │        started at 2026-02-23T10:26:32.874
first test    (1) │     0.21 │   0.00 │  0.0 │      30.71 │   378.98 │
second test   (1) │        started at 2026-02-23T10:26:34.700
second test   (1) |         crashed at 2026-02-23T10:26:35.219

Output generated during execution of 'first test':
┌ Precompiling packages...
│     502.1 ms  ✓ ParallelTestRunner
│   1 dependency successfully precompiled in 1 seconds. 35 already precompiled.
└   Activating new project at `/var/folders/wc/z_cydqs118735x03cvsf96tr0000gn/T/jl_5Vo7BU`

Test Summary:   | Pass  Error  Total  Time
  Overall       |    1      1      2  5.2s
    first test  |    1             1  0.2s
    second test |           1      1  0.5s
    FAILURE

Error in testset second test:
Error During Test at none:1
  Got exception outside of a @test
  Remote exception from Malt.Worker on port 9179 with PID 42179:
  
  ArgumentError: Package ParallelTestRunner not found in current path, maybe you meant `import/using .ParallelTestRunner`.
  - Otherwise, run `import Pkg; Pkg.add("ParallelTestRunner")` to install the ParallelTestRunner package.
  Stacktrace:
   [1] macro expansion
     @ ./loading.jl:2403 [inlined]
   [2] macro expansion
     @ ./lock.jl:376 [inlined]
   [3] __require(into::Module, mod::Symbol)
     @ Base ./loading.jl:2386
   [4] require(into::Module, mod::Symbol)
     @ Base ./loading.jl:2362
   [5] eval(m::Module, e::Any)
     @ Core ./boot.jl:489
   [6] (::var"#handle##0#handle##1"{Sockets.TCPSocket, UInt64, Bool, @Kwargs{}, Tuple{Module, Expr}, typeof(Core.eval)})()
     @ Main ~/.julia/packages/Malt/yA40d/src/worker.jl:120
ERROR: LoadError: Test run finished with errors
in expression starting at /Users/tim/Julia/pkg/ParallelTestRunner/wip.jl:15
```

Also add `workspace` entries for 1.12.