### PR TITLE
Forward code coverage flags.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -431,6 +431,20 @@ function test_exe(color::Bool=false)
     push!(test_exeflags.exec, "--depwarn=yes")
     push!(test_exeflags.exec, "--project=$(Base.active_project())")
     push!(test_exeflags.exec, "--color=$(color ? "yes" : "no")")
+
+    opts = Base.JLOptions()
+    if opts.code_coverage == 1
+        push!(test_exeflags.exec, "--code-coverage=user")
+    elseif opts.code_coverage == 2
+        if opts.output_code_coverage != C_NULL
+            push!(test_exeflags.exec, "--code-coverage=$(unsafe_string(opts.output_code_coverage))")
+        else
+            push!(test_exeflags.exec, "--code-coverage=all")
+        end
+    elseif opts.code_coverage == 3
+        push!(test_exeflags.exec, "--code-coverage=@$(unsafe_string(opts.tracked_path))")
+    end
+
     return test_exeflags
 end
 


### PR DESCRIPTION
`julia_cmd` doesn't forward code coverage options, so we need to do this explicitly.