### PR TITLE
Don't force `--check-bounds`, `--depwarn`, `--startup-file=no`

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -423,12 +423,6 @@ end
 
 function test_exe(color::Bool=false)
     test_exeflags = Base.julia_cmd()
-    filter!(test_exeflags.exec) do c
-        !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
-    end
-    push!(test_exeflags.exec, "--check-bounds=yes")
-    push!(test_exeflags.exec, "--startup-file=no")
-    push!(test_exeflags.exec, "--depwarn=yes")
     push!(test_exeflags.exec, "--project=$(Base.active_project())")
     push!(test_exeflags.exec, "--color=$(color ? "yes" : "no")")
     return test_exeflags


### PR DESCRIPTION
While I completely agree these flags are good practices, I don't think we should _**enforce**_ them, there are legitimate cases for users to try different configurations.

If this is too blunt, I'd be ok with forcing these flags only if not otherwise specified by the user.