### PR TITLE
Revert "Forward code coverage flags."

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.4.1"
+version = "2.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -425,20 +425,6 @@ function test_exe(color::Bool=false)
     test_exeflags = Base.julia_cmd()
     push!(test_exeflags.exec, "--project=$(Base.active_project())")
     push!(test_exeflags.exec, "--color=$(color ? "yes" : "no")")
-
-    opts = Base.JLOptions()
-    if opts.code_coverage == 1
-        push!(test_exeflags.exec, "--code-coverage=user")
-    elseif opts.code_coverage == 2
-        if opts.output_code_coverage != C_NULL
-            push!(test_exeflags.exec, "--code-coverage=$(unsafe_string(opts.output_code_coverage))")
-        else
-            push!(test_exeflags.exec, "--code-coverage=all")
-        end
-    elseif opts.code_coverage == 3
-        push!(test_exeflags.exec, "--code-coverage=@$(unsafe_string(opts.tracked_path))")
-    end
-
     return test_exeflags
 end
 


### PR DESCRIPTION
Reverts JuliaTesting/ParallelTestRunner.jl#94

Looking at the flag forwarding behavior of `julia_cmd()` as part of https://github.com/JuliaTesting/ParallelTestRunner.jl/pull/96, it turns out the non-forwarding design is very much intended:

```
❯ julia --code-coverage=user -e 'println(Base.julia_cmd())'
`julia -C native -g1 --code-coverage=user`

~
❯ julia --code-coverage="lcov-%p.info" -e 'println(Base.julia_cmd())'
`julia -C native -g1 --code-coverage=all --code-coverage=/Users/tim/lcov-%p.info`

~
❯ julia --code-coverage="lcov.info" -e 'println(Base.julia_cmd())'
`julia -C native -g1`
```

i.e. there is an `if isempty(coverage_file) || occursin("%p", coverage_file)` check to avoid clobbering the same output file.