### PR TITLE
Use Base.Semaphore to control test execution parallelism

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Dates = "1"
 IOCapture = "0.2.5, 1"
-Malt = "1.4.0"
+Malt = "1.4.1"
 Printf = "1"
 Random = "1"
 Scratch = "1.3.0"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1027,127 +1027,117 @@ function runtests(mod::Module, args::ParsedArgs;
     #
 
     tests_to_start = Threads.Atomic{Int}(length(tests))
-    @sync for test in tests
-        push!(worker_tasks, Threads.@spawn begin
-            local p = nothing
-            acquired = false
-            try
-                Base.acquire(sem)
-                acquired = true
-                p = take!(worker_pool)
-                Threads.atomic_sub!(tests_to_start, 1)
+    try
+        @sync for test in tests
+            push!(worker_tasks, Threads.@spawn begin
+                local p = nothing
+                acquired = false
+                try
+                    Base.acquire(sem)
+                    acquired = true
+                    p = take!(worker_pool)
+                    Threads.atomic_sub!(tests_to_start, 1)
 
-                done && return
+                    done && return
 
-                test_t0 = Base.@lock test_lock begin
-                    test_t0 = time()
-                    running_tests[test] = test_t0
-                end
-
-                # pass in init_worker_code to custom worker function if defined
-                wrkr = if init_worker_code == :()
-                    test_worker(test)
-                else
-                    test_worker(test, init_worker_code)
-                end
-                if wrkr === nothing
-                    wrkr = p
-                end
-                # if a worker failed, spawn a new one
-                if wrkr === nothing || !Malt.isrunning(wrkr)
-                    wrkr = p = addworker(; init_worker_code, io_ctx.color)
-                end
-
-                # run the test
-                put!(printer_channel, (:started, test, worker_id(wrkr)))
-                result = try
-                    Malt.remote_eval_wait(Main, wrkr.w, :(import ParallelTestRunner))
-                    Malt.remote_call_fetch(invokelatest, wrkr.w, runtest,
-                                           testsuite[test], test, init_code, test_t0)
-                catch ex
-                    if isa(ex, InterruptException)
-                        # the worker got interrupted, signal other tasks to stop
-                        stop_work()
-                        return
+                    test_t0 = Base.@lock test_lock begin
+                        test_t0 = time()
+                        running_tests[test] = test_t0
                     end
 
-                    ex
-                end
-                test_t1 = time()
-                output = Base.@lock  wrkr.io_lock String(take!(wrkr.io))
-                Base.@lock results_lock push!(results, (; test, result, output, test_t0, test_t1))
-
-                # act on the results
-                if result isa AbstractTestRecord
-                    put!(printer_channel, (:finished, test, worker_id(wrkr), result))
-                    if anynonpass(result[]) && args.quickfail !== nothing
-                        stop_work()
-                        return
+                    # pass in init_worker_code to custom worker function if defined
+                    wrkr = if init_worker_code == :()
+                        test_worker(test)
+                    else
+                        test_worker(test, init_worker_code)
+                    end
+                    if wrkr === nothing
+                        wrkr = p
+                    end
+                    # if a worker failed, spawn a new one
+                    if wrkr === nothing || !Malt.isrunning(wrkr)
+                        wrkr = p = addworker(; init_worker_code, io_ctx.color)
                     end
 
-                    if memory_usage(result) > max_worker_rss
-                        # the worker has reached the max-rss limit, recycle it
-                        # so future tests start with a smaller working set
+                    # run the test
+                    put!(printer_channel, (:started, test, worker_id(wrkr)))
+                    result = try
+                        Malt.remote_eval_wait(Main, wrkr.w, :(import ParallelTestRunner))
+                        Malt.remote_call_fetch(invokelatest, wrkr.w, runtest,
+                                               testsuite[test], test, init_code, test_t0)
+                    catch ex
+                        if isa(ex, InterruptException)
+                            # the worker got interrupted, signal other tasks to stop
+                            stop_work()
+                            return
+                        end
+
+                        ex
+                    end
+                    test_t1 = time()
+                    output = Base.@lock  wrkr.io_lock String(take!(wrkr.io))
+                    Base.@lock results_lock push!(results, (; test, result, output, test_t0, test_t1))
+
+                    # act on the results
+                    if result isa AbstractTestRecord
+                        put!(printer_channel, (:finished, test, worker_id(wrkr), result))
+                        if anynonpass(result[]) && args.quickfail !== nothing
+                            stop_work()
+                            return
+                        end
+
+                        if memory_usage(result) > max_worker_rss
+                            # the worker has reached the max-rss limit, recycle it
+                            # so future tests start with a smaller working set
+                            Malt.stop(wrkr)
+                        end
+                    else
+                        # One of Malt.TerminatedWorkerException, Malt.RemoteException, or ErrorException
+                        @assert result isa Exception
+                        put!(printer_channel, (:crashed, test, worker_id(wrkr)))
+                        if args.quickfail !== nothing
+                            stop_work()
+                            return
+                        end
+
+                        # the worker encountered some serious failure, recycle it
                         Malt.stop(wrkr)
                     end
-                else
-                    # One of Malt.TerminatedWorkerException, Malt.RemoteException, or ErrorException
-                    @assert result isa Exception
-                    put!(printer_channel, (:crashed, test, worker_id(wrkr)))
-                    if args.quickfail !== nothing
-                        stop_work()
-                        return
+
+                    # get rid of the custom worker
+                    if wrkr != p
+                        Malt.stop(wrkr)
                     end
 
-                    # the worker encountered some serious failure, recycle it
-                    Malt.stop(wrkr)
-                end
-
-                # get rid of the custom worker
-                if wrkr != p
-                    Malt.stop(wrkr)
-                end
-
-                Base.@lock test_lock begin
-                    delete!(running_tests, test)
-                end
-            catch ex
-                isa(ex, InterruptException) || rethrow()
-            finally
-                if acquired
-                    # stop the worker if no more tests will need one from the pool
-                    if tests_to_start[] == 0 && p !== nothing && Malt.isrunning(p)
-                        Malt.stop(p)
-                        p = nothing
+                    Base.@lock test_lock begin
+                        delete!(running_tests, test)
                     end
-                    put!(worker_pool, p)
-                    Base.release(sem)
+                catch ex
+                    isa(ex, InterruptException) || rethrow()
+                finally
+                    if acquired
+                        # stop the worker if no more tests will need one from the pool
+                        if tests_to_start[] == 0 && p !== nothing && Malt.isrunning(p)
+                            Malt.stop(p)
+                            p = nothing
+                        end
+                        put!(worker_pool, p)
+                        Base.release(sem)
+                    end
                 end
-            end
-        end)
+            end)
+        end
+    catch err
+        if !(err isa InterruptException)
+            println(io_ctx.stderr, "\nCaught an error, stopping...")
+        end
+    finally
+        stop_work()
     end
 
     #
     # finalization
     #
-
-    # monitor worker tasks for failure so that each one doesn't need a try/catch + stop_work()
-    try
-        while true
-            if any(istaskfailed, worker_tasks)
-                println(io_ctx.stderr, "\nCaught an error, stopping...")
-                break
-            elseif done || Base.@lock(test_lock, isempty(running_tests) && length(results) >= length(tests))
-                break
-            end
-            sleep(1)
-        end
-    catch err
-        # in case the sleep got interrupted
-        isa(err, InterruptException) || rethrow()
-    finally
-        stop_work()
-    end
 
     # wait for the printer to finish so that all results have been printed
     close(printer_channel)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1039,7 +1039,6 @@ function runtests(mod::Module, args::ParsedArgs;
                 test_t0 = Base.@lock test_lock begin
                     test_t0 = time()
                     running_tests[test] = test_t0
-                    test_t0
                 end
 
                 # pass in init_worker_code to custom worker function if defined

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -925,10 +925,10 @@ function runtests(mod::Module, args::ParsedArgs;
                 est_remaining += max(0.0, duration - elapsed)
             end
             ## yet-to-run
-            completed_names = Set{String}(r[1] for r in results)
             for test in tests
                 haskey(running_tests, test) && continue
-                test in completed_names && continue
+                # Test is in any completed test
+                any(r -> test == r.test, results) && continue
                 est_remaining += get(historical_durations, test, est_per_test)
             end
 
@@ -1072,7 +1072,7 @@ function runtests(mod::Module, args::ParsedArgs;
                 end
                 test_t1 = time()
                 output = String(take!(wrkr.io))
-                push!(results, (test, result, output, test_t0, test_t1))
+                push!(results, (; test, result, output, test_t0, test_t1))
 
                 # act on the results
                 if result isa AbstractTestRecord

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -826,7 +826,7 @@ function runtests(mod::Module, args::ParsedArgs;
     jobs = clamp(jobs, 1, length(tests))
     println(stdout, "Running $(length(tests)) tests using $jobs parallel jobs. If this is too many concurrent jobs, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.")
     !isnothing(args.verbose) && println(stdout, "Available memory: $(Base.format_bytes(available_memory()))")
-    sem = Base.Semaphore(jobs)
+    sem = Base.Semaphore(max(1, jobs))
     worker_pool = Channel{Union{Nothing, PTRWorker}}(jobs)
     for _ in 1:jobs
         put!(worker_pool, nothing)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1024,8 +1024,8 @@ function runtests(mod::Module, args::ParsedArgs;
     #
 
     tests_to_start = Threads.Atomic{Int}(length(tests))
-    for test in tests
-        push!(worker_tasks, @async begin
+    @sync for test in tests
+        push!(worker_tasks, Threads.@spawn begin
             local p = nothing
             acquired = false
             try

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -826,7 +826,11 @@ function runtests(mod::Module, args::ParsedArgs;
     jobs = clamp(jobs, 1, length(tests))
     println(stdout, "Running $(length(tests)) tests using $jobs parallel jobs. If this is too many concurrent jobs, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.")
     !isnothing(args.verbose) && println(stdout, "Available memory: $(Base.format_bytes(available_memory()))")
-    workers = fill(nothing, jobs)
+    sem = Base.Semaphore(jobs)
+    worker_pool = Channel{Union{Nothing, PTRWorker}}(jobs)
+    for _ in 1:jobs
+        put!(worker_pool, nothing)
+    end
 
     t0 = time()
     results = []
@@ -887,7 +891,7 @@ function runtests(mod::Module, args::ParsedArgs;
         # only draw if we have something to show
         isempty(running_tests) && return
         completed = length(results)
-        total = completed + length(tests) + length(running_tests)
+        total = length(tests)
 
         # line 1: empty line
         line1 = ""
@@ -921,7 +925,10 @@ function runtests(mod::Module, args::ParsedArgs;
                 est_remaining += max(0.0, duration - elapsed)
             end
             ## yet-to-run
+            completed_names = Set{String}(r[1] for r in results)
             for test in tests
+                haskey(running_tests, test) && continue
+                test in completed_names && continue
                 est_remaining += get(historical_durations, test, est_per_test)
             end
 
@@ -1004,7 +1011,7 @@ function runtests(mod::Module, args::ParsedArgs;
             end
             isa(ex, InterruptException) || rethrow()
         finally
-            if isempty(tests) && isempty(running_tests)
+            if isempty(running_tests) && length(results) >= length(tests)
                 # XXX: only erase the status if we completed successfully.
                 #      in other cases we'll have printed "caught interrupt"
                 clear_status()
@@ -1012,23 +1019,27 @@ function runtests(mod::Module, args::ParsedArgs;
         end
     end
 
-
     #
     # execution
     #
 
-    for p in workers
+    tests_to_start = Threads.Atomic{Int}(length(tests))
+    for test in tests
         push!(worker_tasks, @async begin
-            while !done
-                # get a test to run
-                test, test_t0 = Base.@lock test_lock begin
-                    isempty(tests) && break
-                    test = popfirst!(tests)
+            local p = nothing
+            acquired = false
+            try
+                Base.acquire(sem)
+                acquired = true
+                p = take!(worker_pool)
+                Threads.atomic_sub!(tests_to_start, 1)
 
+                done && return
+
+                test_t0 = Base.@lock test_lock begin
                     test_t0 = time()
                     running_tests[test] = test_t0
-
-                    test, test_t0
+                    test_t0
                 end
 
                 # pass in init_worker_code to custom worker function if defined
@@ -1055,7 +1066,7 @@ function runtests(mod::Module, args::ParsedArgs;
                     if isa(ex, InterruptException)
                         # the worker got interrupted, signal other tasks to stop
                         stop_work()
-                        break
+                        return
                     end
 
                     ex
@@ -1069,7 +1080,7 @@ function runtests(mod::Module, args::ParsedArgs;
                     put!(printer_channel, (:finished, test, worker_id(wrkr), result))
                     if anynonpass(result[]) && args.quickfail !== nothing
                         stop_work()
-                        break
+                        return
                     end
 
                     if memory_usage(result) > max_worker_rss
@@ -1083,7 +1094,7 @@ function runtests(mod::Module, args::ParsedArgs;
                     put!(printer_channel, (:crashed, test, worker_id(wrkr)))
                     if args.quickfail !== nothing
                         stop_work()
-                        break
+                        return
                     end
 
                     # the worker encountered some serious failure, recycle it
@@ -1098,13 +1109,21 @@ function runtests(mod::Module, args::ParsedArgs;
                 Base.@lock test_lock begin
                     delete!(running_tests, test)
                 end
-            end
-            if p !== nothing
-                Malt.stop(p)
+            catch ex
+                isa(ex, InterruptException) || rethrow()
+            finally
+                if acquired
+                    # stop the worker if no more tests will need one from the pool
+                    if tests_to_start[] == 0 && p !== nothing && Malt.isrunning(p)
+                        Malt.stop(p)
+                        p = nothing
+                    end
+                    put!(worker_pool, p)
+                    Base.release(sem)
+                end
             end
         end)
     end
-
 
     #
     # finalization
@@ -1116,7 +1135,7 @@ function runtests(mod::Module, args::ParsedArgs;
             if any(istaskfailed, worker_tasks)
                 println(io_ctx.stderr, "\nCaught an error, stopping...")
                 break
-            elseif done || Base.@lock(test_lock, isempty(tests) && isempty(running_tests))
+            elseif done || Base.@lock(test_lock, isempty(running_tests) && length(results) >= length(tests))
                 break
             end
             sleep(1)
@@ -1143,6 +1162,14 @@ function runtests(mod::Module, args::ParsedArgs;
             end
 
             isa(err, InterruptException) || rethrow()
+        end
+    end
+
+    # clean up remaining workers in the pool
+    close(worker_pool)
+    for p in worker_pool
+        if p !== nothing && Malt.isrunning(p)
+            Malt.stop(p)
         end
     end
 
@@ -1227,7 +1254,7 @@ function runtests(mod::Module, args::ParsedArgs;
             end
 
             # mark remaining or running tests as interrupted
-            for test in [tests; collect(keys(running_tests))]
+            for test in tests
                 (test in completed_tests) && continue
                 testset = create_testset(test)
                 Test.record(testset, Test.Error(:test_interrupted, test, nothing, Base.ExceptionStack(NamedTuple[(;exception = "skipped", backtrace = [])]), LineNumberNode(1)))

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -836,6 +836,7 @@ function runtests(mod::Module, args::ParsedArgs;
     results = []
     running_tests = Dict{String, Float64}()  # test => start_time
     test_lock = ReentrantLock() # to protect crucial access to tests and running_tests
+    results_lock = ReentrantLock() # to protect concurrent access to results
 
     worker_tasks = Task[]
 
@@ -1072,7 +1073,7 @@ function runtests(mod::Module, args::ParsedArgs;
                 end
                 test_t1 = time()
                 output = String(take!(wrkr.io))
-                push!(results, (; test, result, output, test_t0, test_t1))
+                Base.@lock results_lock push!(results, (; test, result, output, test_t0, test_t1))
 
                 # act on the results
                 if result isa AbstractTestRecord


### PR DESCRIPTION
This is a refactoring of the code, to then enable #77 in a follow up PR (CC @christiangnrd).

The idea of using a semaphore is mine, initial implementation is from Claude, but I made a few manual refinements afterwards (some of them folded in the first commit).  Overall summary of the changes:

> Replace the fixed worker-task-per-slot model with a semaphore-based
> approach: one task per test, with a Base.Semaphore(jobs) limiting
> concurrency and a Channel-based worker pool for reuse. This decouples
> the number of tasks from the parallelism level and simplifies the
> control flow (no inner while loop, tests array is immutable).

I'm mostly happy about the result, it's very close to what I had in mind, and the net diff is relatively small (+48/-22), so this shouldn't be too hard to review.

#118 was useful because it detected that the case of no tests to run [wasn't handled correctly](https://github.com/JuliaTesting/ParallelTestRunner.jl/commit/62bb315cb608cfbce24ebdb9d79deee60fa35c53), so yay for the extra tests.