### PR TITLE
Fix styling in print_header function

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -141,7 +141,7 @@ function print_header(ctx::TestIOContext, testgroupheader, workerheader)
     lock(ctx.lock)
     try
         # header top
-        printstyled(ctx.stdout, " "^(ctx.name_align + textwidth(testgroupheader) - 3), " │ ")
+        printstyled(ctx.stdout, " "^(ctx.name_align + textwidth(testgroupheader) - 3), " │ ", color = :white)
         printstyled(ctx.stdout, "  Test   │", color = :white)
         ctx.verbose && printstyled(ctx.stdout, "   Init   │", color = :white)
         VERSION >= v"1.11" && ctx.verbose && printstyled(ctx.stdout, " Compile │", color = :white)


### PR DESCRIPTION
Noticed in Zed:
<img width="613" height="44" alt="image" src="https://github.com/user-attachments/assets/b5e7a560-8a43-4890-891e-0fce5dfb7448" />

This is the only instance of `printstyled` without a specified colour.