### PR TITLE
Make `--list` always list all tests, even filtered ones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
 /docs/build/
+*.cov

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -761,8 +761,16 @@ end
 Filter tests in `testsuite` based on command-line arguments in `args`.
 
 Returns `true` if additional filtering may be done by the caller, `false` otherwise.
+
+When `--list` is requested, the full `testsuite` is preserved and `false` is
+returned so that callers skip any conditional filtering of their own: listing
+should show every available test, not just the ones that would run by default.
 """
 function filter_tests!(testsuite, args::ParsedArgs)
+    # when only listing tests, keep the full catalog and let the caller skip its
+    # own filtering, so that every available test is shown
+    args.list !== nothing && return false
+
     # the user did not request specific tests, so let the caller do its own filtering
     isempty(args.positionals) && return true
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -713,6 +713,20 @@ end
         @test filter_tests!(testsuite, args) == false
         @test isempty(testsuite)
     end
+
+    @testset "listing preserves all tests" begin
+        testsuite = Dict("a" => :(), "b" => :(), "c" => :())
+        args = parse_args(["--list"])
+        @test filter_tests!(testsuite, args) == false
+        @test length(testsuite) == 3
+    end
+
+    @testset "listing ignores positional filters" begin
+        testsuite = Dict("a" => :(), "b" => :())
+        args = parse_args(["--list", "a"])
+        @test filter_tests!(testsuite, args) == false
+        @test length(testsuite) == 2
+    end
 end
 
 @testset "find_tests edge cases" begin


### PR DESCRIPTION
As requested by @christiangnrd 