### PR TITLE
Start tests in sorted order also with multiple threads

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -60,3 +60,5 @@ jobs:
           arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: "auto"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1189,10 +1189,12 @@ function _runtests(mod::Module, args::ParsedArgs;
     #
 
     tests_to_start = Threads.Atomic{Int}(length(tests))
+    next_test = Threads.Atomic{Int}(1)
     try
-        @sync for test in tests
+        @sync for _ in 1:length(tests)
             push!(worker_tasks, Threads.@spawn begin
                 local p = nothing
+                local test
                 acquired = false
                 try
                     Base.acquire(sem)
@@ -1201,6 +1203,11 @@ function _runtests(mod::Module, args::ParsedArgs;
                     Threads.atomic_sub!(tests_to_start, 1)
 
                     done && return
+
+                    # with multiple threads, tasks reach this point in arbitrary order,
+                    # so pick the next test to run only now, rather than at spawn time,
+                    # to preserve the sorted test order (issue #139)
+                    test = tests[Threads.atomic_add!(next_test, 1)]
 
                     test_t0 = @lock running_tests begin
                         test_t0 = time()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,6 @@ cd(@__DIR__)
 
 include(joinpath(@__DIR__, "utils.jl"))
 
-# dummy module to give the "test start order" testset its own history file,
-# without clobbering the history of `ParallelTestRunner` used by other testsets
-module SortingHistoryDummy end
-
 @testset "ParallelTestRunner" verbose=true begin
 
 @testset "basic use" begin
@@ -76,26 +72,28 @@ end
 end
 
 @testset "test start order" begin
-    # tests must start in descending order of historical duration, regardless of
-    # the number of threads of this process (issue #139)
+    # Tests must start in the given order, regardless of the
+    # number of threads of the host Julia process (issue #139).
     testsuite = Dict(
-        name => :(@test true)
-        for name in ("sort1", "sort2", "sort3", "sort4", "sort5")
+        "sort$(n)" => :(@test true)
+        for n in 1:5
     )
-    # deliberately not in alphabetical order, so that tests accidentally started in
-    # alphabetical (or insertion) order would not pass the test below
-    expected_order = ["sort3", "sort1", "sort5", "sort2", "sort4"]
-    ParallelTestRunner.save_test_history(SortingHistoryDummy,
-        Dict(name => Float64(length(expected_order) - idx)
-             for (idx, name) in enumerate(expected_order)))
+    tests = ["sort$(n)" for n in 1:length(testsuite)]
 
     io = IOBuffer()
     # with a single job, tests start strictly in acquisition order
-    runtests(SortingHistoryDummy, ["--jobs=1", "--verbose"]; testsuite, stdout=io, stderr=io)
+    ParallelTestRunner._runtests(
+        ParallelTestRunner, parse_args(["--jobs=1", "--verbose"]);
+        testsuite,
+        tests,
+        historical_durations=Dict{String, Float64}(),
+        stdout=io,
+        stderr=io,
+    )
 
     str = String(take!(io))
     @test contains(str, "SUCCESS")
-    started_at = map(expected_order) do name
+    started_at = map(tests) do name
         m = match(Regex("$(name) .+ started at"), str)
         @test m !== nothing
         m === nothing ? typemax(Int) : m.offset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,10 @@ cd(@__DIR__)
 
 include(joinpath(@__DIR__, "utils.jl"))
 
+# dummy module to give the "test start order" testset its own history file,
+# without clobbering the history of `ParallelTestRunner` used by other testsets
+module SortingHistoryDummy end
+
 @testset "ParallelTestRunner" verbose=true begin
 
 @testset "basic use" begin
@@ -69,6 +73,34 @@ end
     @test !contains(str, r"basic .+ started at")
     @test contains(str, r"custom .+ started at")
     @test contains(str, "SUCCESS")
+end
+
+@testset "test start order" begin
+    # tests must start in descending order of historical duration, regardless of
+    # the number of threads of this process (issue #139)
+    testsuite = Dict(
+        name => :(@test true)
+        for name in ("sort1", "sort2", "sort3", "sort4", "sort5")
+    )
+    # deliberately not in alphabetical order, so that tests accidentally started in
+    # alphabetical (or insertion) order would not pass the test below
+    expected_order = ["sort3", "sort1", "sort5", "sort2", "sort4"]
+    ParallelTestRunner.save_test_history(SortingHistoryDummy,
+        Dict(name => Float64(length(expected_order) - idx)
+             for (idx, name) in enumerate(expected_order)))
+
+    io = IOBuffer()
+    # with a single job, tests start strictly in acquisition order
+    runtests(SortingHistoryDummy, ["--jobs=1", "--verbose"]; testsuite, stdout=io, stderr=io)
+
+    str = String(take!(io))
+    @test contains(str, "SUCCESS")
+    started_at = map(expected_order) do name
+        m = match(Regex("$(name) .+ started at"), str)
+        @test m !== nothing
+        m === nothing ? typemax(Int) : m.offset
+    end
+    @test issorted(started_at)
 end
 
 @testset "init code" begin


### PR DESCRIPTION
Since #119, each test is bound to its own task at spawn time, and all tasks race to acquire the semaphore.  With a single thread tasks happen to reach the semaphore in spawn order, but with multiple threads the acquisition order is arbitrary, defeating the descending-historical- duration sort (#139).

Instead, hand out tests in sorted order at acquisition time, via an atomic fetch-add index claimed only once a task holds a semaphore slot and a worker.

Fixes #139. @christiangnrd can you please test this PR?  It does seem to work for me, tests introduced in #140 now pass when using multiple Julia threads, which instead very frequently currently fail, as explained in https://github.com/JuliaTesting/ParallelTestRunner.jl/pull/140#discussion_r3516520155.