### PR TITLE
Allow tweaking `memory_per_worker` for testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Usage: runtests.jl [--help] [--list] [--jobs=N] [TESTS...]
    --list             List all available tests.
    --verbose          Print more information during testing.
    --quickfail        Fail the entire run as soon as a single test errored.
-   --jobs=N           Launch `N` processes to perform tests.
+   --jobs=N           Launch `N` processes to perform tests. Can also be set
+                      with the PARALLELTESTRUNNER_NUM_JOBS environment
+                      variable, with `--jobs=N` taking precedence.
 
    Remaining arguments filter the tests that will be executed.
 ```

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -498,23 +498,23 @@ end
 
 # Assumed memory footprint of a single test worker, used to clamp the default
 # number of jobs on memory-constrained machines (e.g. many cores but little
-# total memory). Packages whose tests are heavier can pass a larger
+# memory). Packages whose tests are heavier can pass a larger
 # `memory_per_worker` to `runtests`.
 const DEFAULT_MEMORY_PER_WORKER = Int64(2)^30
 
 # This is an internal function, not to be used by end users.  The
-# `cpu_threads` and `total_memory` keyword arguments are only for testing
+# `cpu_threads` and `free_memory` keyword arguments are only for testing
 # purposes.
 """
     default_njobs(; memory_per_worker = 2^30)
 
 Determine default number of parallel jobs: the number of CPU threads, clamped
 such that each worker can be assumed to use `memory_per_worker` bytes of the
-total system memory.
+available system memory.
 """
-function default_njobs(; cpu_threads = Sys.CPU_THREADS, total_memory = Sys.total_memory(),
+function default_njobs(; cpu_threads = Sys.CPU_THREADS, free_memory = available_memory(),
                          memory_per_worker = DEFAULT_MEMORY_PER_WORKER)
-    memory_jobs = Int64(total_memory) ÷ Int64(memory_per_worker)
+    memory_jobs = round(Int, Int64(free_memory) / memory_per_worker)
     return max(1, min(cpu_threads, memory_jobs))
 end
 
@@ -866,7 +866,7 @@ Several keyword arguments are also supported:
 - `--list`: List all available test files and exit
 - `--verbose`: Print more detailed information during test execution
 - `--quickfail`: Stop the entire test run as soon as any test fails
-- `--jobs=N`: Use N worker processes (default: based on CPU threads and total memory;
+- `--jobs=N`: Use N worker processes (default: based on CPU threads and available memory;
   can also be set with the `PARALLELTESTRUNNER_NUM_JOBS` environment variable, with
   `--jobs=N` taking precedence)
 - `TESTS...`: Filter test files by name, matched using `startswith`

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -496,17 +496,26 @@ available_memory() = Sys.free_memory()
 
 end
 
-# This is an internal function, not to be used by end users.  The keyword
-# arguments are only for testing purposes.
-"""
-    default_njobs()
+# Assumed memory footprint of a single test worker, used to clamp the default
+# number of jobs on memory-constrained machines (e.g. many cores but little
+# total memory). Packages whose tests are heavier can pass a larger
+# `memory_per_worker` to `runtests`.
+const DEFAULT_MEMORY_PER_WORKER = Int64(2)^30
 
-Determine default number of parallel jobs.
+# This is an internal function, not to be used by end users.  The
+# `cpu_threads` and `total_memory` keyword arguments are only for testing
+# purposes.
 """
-function default_njobs(; cpu_threads = Sys.CPU_THREADS, free_memory = available_memory())
-    jobs = cpu_threads
-    memory_jobs = Int64(free_memory) ÷ (2 * Int64(2)^30)
-    return max(1, min(jobs, memory_jobs))
+    default_njobs(; memory_per_worker = 2^30)
+
+Determine default number of parallel jobs: the number of CPU threads, clamped
+such that each worker can be assumed to use `memory_per_worker` bytes of the
+total system memory.
+"""
+function default_njobs(; cpu_threads = Sys.CPU_THREADS, total_memory = Sys.total_memory(),
+                         memory_per_worker = DEFAULT_MEMORY_PER_WORKER)
+    memory_jobs = Int64(total_memory) ÷ Int64(memory_per_worker)
+    return max(1, min(cpu_threads, memory_jobs))
 end
 
 # Historical test duration database
@@ -723,7 +732,9 @@ function parse_args(args; custom::Array{String} = String[])
                --list             List all available tests.
                --verbose          Print more information during testing.
                --quickfail        Fail the entire run as soon as a single test errored.
-               --jobs=N           Launch `N` processes to perform tests."""
+               --jobs=N           Launch `N` processes to perform tests. Can also be set
+                                  with the PARALLELTESTRUNNER_NUM_JOBS environment
+                                  variable, with `--jobs=N` taking precedence."""
 
         if !isempty(custom)
             usage *= "\n\nCustom arguments:"
@@ -799,7 +810,8 @@ end
              env = Vector{Pair{String, String}}(),
              stdout = Base.stdout,
              stderr = Base.stderr,
-             max_worker_rss = get_max_worker_rss())
+             max_worker_rss = get_max_worker_rss(),
+             memory_per_worker = 2^30)
     runtests(mod::Module, ARGS; ...)
 
 Run Julia tests in parallel across multiple worker processes.
@@ -842,6 +854,11 @@ Several keyword arguments are also supported:
   `test_worker` hook are the caller's responsibility.
 - `stdout` and `stderr`: I/O streams to write to (default: `Base.stdout` and `Base.stderr`)
 - `max_worker_rss`: RSS threshold where a worker will be restarted once it is reached.
+- `memory_per_worker`: Assumed memory footprint (in bytes) of a single worker, used to
+  clamp the default number of jobs on memory-constrained machines (default: 1 GiB).
+  Packages whose tests use a lot of memory can pass a larger value to reduce the default
+  parallelism. Ignored when the number of jobs is set explicitly via `--jobs=N` or the
+  `PARALLELTESTRUNNER_NUM_JOBS` environment variable.
 
 ## Command Line Options
 
@@ -849,7 +866,9 @@ Several keyword arguments are also supported:
 - `--list`: List all available test files and exit
 - `--verbose`: Print more detailed information during test execution
 - `--quickfail`: Stop the entire test run as soon as any test fails
-- `--jobs=N`: Use N worker processes (default: based on CPU threads and available memory)
+- `--jobs=N`: Use N worker processes (default: based on CPU threads and total memory;
+  can also be set with the `PARALLELTESTRUNNER_NUM_JOBS` environment variable, with
+  `--jobs=N` taking precedence)
 - `TESTS...`: Filter test files by name, matched using `startswith`
 
 ## Behavior
@@ -922,7 +941,8 @@ function runtests(mod::Module, args::ParsedArgs;
                   exename = nothing,
                   exeflags = nothing,
                   env = Vector{Pair{String, String}}(),
-                  stdout = Base.stdout, stderr = Base.stderr, max_worker_rss = get_max_worker_rss())
+                  stdout = Base.stdout, stderr = Base.stderr, max_worker_rss = get_max_worker_rss(),
+                  memory_per_worker = DEFAULT_MEMORY_PER_WORKER)
 
     #
     # set-up
@@ -962,6 +982,7 @@ function runtests(mod::Module, args::ParsedArgs;
         stdout,
         stderr,
         max_worker_rss,
+        memory_per_worker,
     )
 end
 
@@ -981,12 +1002,14 @@ function _runtests(mod::Module, args::ParsedArgs;
                    stdout = Base.stdout,
                    stderr = Base.stderr,
                    max_worker_rss = get_max_worker_rss(),
+                   memory_per_worker = DEFAULT_MEMORY_PER_WORKER,
                    )
 
     # determine parallelism
-    jobs = something(args.jobs, default_njobs())
+    env_jobs = tryparse(Int, get(ENV, "PARALLELTESTRUNNER_NUM_JOBS", ""))
+    jobs = @something args.jobs env_jobs default_njobs(; memory_per_worker)
     jobs = clamp(jobs, 1, length(tests))
-    println(stdout, "Running $(length(tests)) tests using $jobs parallel jobs. If this is too many concurrent jobs, specify the `--jobs=N` argument to the tests, or set the `JULIA_CPU_THREADS` environment variable.")
+    println(stdout, "Running $(length(tests)) tests using $jobs parallel jobs. To change the number of jobs, specify the `--jobs=N` argument to the tests, or set the `PARALLELTESTRUNNER_NUM_JOBS` environment variable.")
     !isnothing(args.verbose) && println(stdout, "Available memory: $(Base.format_bytes(available_memory()))")
     sem = Base.Semaphore(max(1, jobs))
     worker_pool = Channel{Union{Nothing, PTRWorker}}(jobs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,14 +40,19 @@ include(joinpath(@__DIR__, "utils.jl"))
 end
 
 @testset "default njobs" begin
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 28) == 1
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 30) == 1
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 31) == 2
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 32) == 4
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 33) == 4
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 28) == 1
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 30) == 1
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 31) == 2
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 32) == 4
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 33) == 4
+
+    # memory jobs are rounded, not floored (a 7 GB CI runner with ~3.3 GiB
+    # available should still get 3 workers)
+    @test ParallelTestRunner.default_njobs(; cpu_threads=3, free_memory=round(UInt64, 3.3 * 2^30)) == 3
+    @test ParallelTestRunner.default_njobs(; cpu_threads=3, free_memory=round(UInt64, 2.7 * 2^30)) == 3
 
     # heavier per-worker memory estimate lowers the default
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 32,
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 32,
                                              memory_per_worker=2 * Int64(2) ^ 30) == 2
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,12 +40,37 @@ include(joinpath(@__DIR__, "utils.jl"))
 end
 
 @testset "default njobs" begin
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 28) == 1
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 30) == 1
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 31) == 1
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 32) == 2
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 33) == 4
-    @test ParallelTestRunner.default_njobs(; cpu_threads=4, free_memory=UInt64(2) ^ 34) == 4
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 28) == 1
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 30) == 1
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 31) == 2
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 32) == 4
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 33) == 4
+
+    # heavier per-worker memory estimate lowers the default
+    @test ParallelTestRunner.default_njobs(; cpu_threads=4, total_memory=UInt64(2) ^ 32,
+                                             memory_per_worker=2 * Int64(2) ^ 30) == 2
+end
+
+@testset "number of jobs" begin
+    testsuite = Dict(
+        "t1" => :(@test true),
+        "t2" => :(@test true),
+        "t3" => :(@test true),
+    )
+
+    # environment variable overrides the default
+    io = IOBuffer()
+    withenv("PARALLELTESTRUNNER_NUM_JOBS" => "2") do
+        runtests(ParallelTestRunner, String[]; testsuite, stdout=io, stderr=io)
+    end
+    @test contains(String(take!(io)), "using 2 parallel jobs")
+
+    # --jobs takes precedence over the environment variable
+    io = IOBuffer()
+    withenv("PARALLELTESTRUNNER_NUM_JOBS" => "2") do
+        runtests(ParallelTestRunner, ["--jobs=1"]; testsuite, stdout=io, stderr=io)
+    end
+    @test contains(String(take!(io)), "using 1 parallel jobs")
 end
 
 @testset "subdir use" begin


### PR DESCRIPTION
I (@christiangnrd) rewrote the message to reflect the actual changes.

This PR adds the `memory_per_worker` kwarg for `runtests` so users can better tweak how many jobs are run in parallel based on their testsuite's memory requirements. Default value stays the same until the next breaking release.

Also adds the `PTR_NUM_JOBS` environment variable so it's easier to ~torture 8GB Mac minis~ override the number of parallel jobs.


<details>
<summary>Original message (outdated)</summary>


Based on the discussion in #73 this PR does the following changes:

- `default_njobs` now computes `min(cpu_threads, total_memory ÷ memory_per_worker)` — it uses total system memory instead of free memory (which measured whatever else happened to be running and made the default non-deterministic), and the per-worker estimate dropped from 2 GiB to 1 GiB (new `DEFAULT_MEMORY_PER_WORKER` constant).
- New `memory_per_worker` kwarg on runtests, threaded through to `default_njobs`, so memory-heavy packages (CUDA.jl, Enzyme.jl) can declare e.g. 3 GiB per worker and get a conservative default without taxing everyone else. Ignored when jobs are set explicitly.
- New `PARALLELTESTRUNNER_NUM_JOBS` env var (name from PR #65) as a CI-friendly override, with precedence `--jobs=N` > env var > computed default.
- Fixed the startup hint that suggested `JULIA_CPU_THREADS` (which didn't work when the memory clamp was binding) to mention the env var; updated `--help` text, README, and docstrings; rewrote/extended the tests.

This has the following effect on the machines in #73: 

```
┌───────────────────────────────────────────────────┬──────────────────────────────┬────────────────┐
│                      Machine                      │            Before            │     After      │
├───────────────────────────────────────────────────┼──────────────────────────────┼────────────────┤
│ M4 (10 cores, free memory ~6 GB at the time)      │ 3                            │ 10 (all cores) │
├───────────────────────────────────────────────────┼──────────────────────────────┼────────────────┤
│ GH macOS aarch64 runner (3 vCPU, 7 GB)            │ 1                            │ 3              │
├───────────────────────────────────────────────────┼──────────────────────────────┼────────────────┤
│ a64fx (48 cores, 32 GB)                           │ ~16, varies with free memory │ 32             │
├───────────────────────────────────────────────────┼──────────────────────────────┼────────────────┤
│ GH ubuntu/windows runners (4 vCPU, 16 GB)         │ usually 4 already            │ 4 (unchanged)  │
└───────────────────────────────────────────────────┴──────────────────────────────┴────────────────┘
```

This seems like much more reasonable defaults to me. Using 3 cores by default on M4 is just not ok :P

</details>

(Claude Fable helped prepare this PR)