### PR TITLE
Add speculative_count to memory calculation

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -487,7 +487,7 @@ function available_memory()
 
 	page_size = Int(@ccall sysconf(29::UInt32)::UInt32)
 
-	return (Int(vms[].free_count) + Int(vms[].inactive_count) + Int(vms[].purgeable_count) + Int(vms[].compressor_page_count)) * page_size
+	return (Int(vms[].free_count) + Int(vms[].inactive_count) + Int(vms[].purgeable_count) + Int(vms[].compressor_page_count) + Int(vms[].speculative_count)) * page_size
 end
 
 else


### PR DESCRIPTION
As I mentioned in https://github.com/JuliaTesting/ParallelTestRunner.jl/pull/142#issuecomment-4948689566, while never a large portion of memory usage, `speculative_count` on macos can probably be considered available.