### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.6.2"
+version = "2.6.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
The only user-facing change would be the fix for the test ordering regression when julia is launched with >1 thread

@giordano tagging since I can't request reviewers