### PR TITLE
Avoid `a[] = v` pattern for atomic variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.6.2"
+version = "2.6.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -54,7 +54,8 @@ function PTRWorker(; exename=Base.julia_cmd()[1], exeflags=String[], env=String[
     io = Lockable(IOBuffer())
     wrkr = Malt.Worker(; exename, exeflags, env, monitor_stdout=false, monitor_stderr=false)
     stdio_loop(wrkr, io)
-    id = ID_COUNTER[] += 1
+    Threads.atomic_add!(ID_COUNTER, 1)
+    id = ID_COUNTER[]
     return PTRWorker(wrkr, io, id)
 end
 

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -41,7 +41,7 @@ else
     Base.unlock(l::Lockable) = Base.unlock(l.lock)
 end
 
-const ID_COUNTER = Threads.Atomic{Int}(0)
+const ID_COUNTER = Threads.Atomic{Int}(1)
 
 # Thin wrapper around Malt.Worker, to handle the stdio loop differently.
 struct PTRWorker <: Malt.AbstractWorker
@@ -54,8 +54,7 @@ function PTRWorker(; exename=Base.julia_cmd()[1], exeflags=String[], env=String[
     io = Lockable(IOBuffer())
     wrkr = Malt.Worker(; exename, exeflags, env, monitor_stdout=false, monitor_stderr=false)
     stdio_loop(wrkr, io)
-    Threads.atomic_add!(ID_COUNTER, 1)
-    id = ID_COUNTER[]
+    id = Threads.atomic_add!(ID_COUNTER, 1)
     return PTRWorker(wrkr, io, id)
 end
 


### PR DESCRIPTION
In preparation for https://github.com/JuliaLang/julia/pull/62382.

Close #145.