### PR TITLE
Fix nightly-only TypeError from synthetic Test.Error backtraces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.6.4"
+version = "2.6.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1415,7 +1415,7 @@ function _runtests(mod::Module, args::ParsedArgs;
                     # One of Malt.TerminatedWorkerException, Malt.RemoteException, or ErrorException
                     @assert result isa Exception
                     testset = create_testset(testname; start, stop)
-                    Test.record(testset, Test.Error(:nontest_error, testname, nothing, Base.ExceptionStack(NamedTuple[(;exception = result, backtrace = [])]), LineNumberNode(1)))
+                    Test.record(testset, Test.Error(:nontest_error, testname, nothing, Base.ExceptionStack(NamedTuple[(;exception = result, backtrace = Union{Ptr{Nothing}, Base.InterpreterIP}[])]), LineNumberNode(1)))
                 end
 
                 with_testset(testset) do
@@ -1427,7 +1427,7 @@ function _runtests(mod::Module, args::ParsedArgs;
             for test in tests
                 (test in completed_tests) && continue
                 testset = create_testset(test)
-                Test.record(testset, Test.Error(:test_interrupted, test, nothing, Base.ExceptionStack(NamedTuple[(;exception = "skipped", backtrace = [])]), LineNumberNode(1)))
+                Test.record(testset, Test.Error(:test_interrupted, test, nothing, Base.ExceptionStack(NamedTuple[(;exception = "skipped", backtrace = Union{Ptr{Nothing}, Base.InterpreterIP}[])]), LineNumberNode(1)))
                 with_testset(testset) do
                     Test.record(o_ts, testset)
                 end


### PR DESCRIPTION
This is the failure discussed in #149 

Claude: Julia master (JuliaLang/julia#62391) now runs `scrub_exc_stack` for `:nontest_error` results too, which asserts the backtrace element type as `Vector{Union{Ptr{Nothing},Base.InterpreterIP}}`. The empty `[]` literal is `Vector{Any}` and fails that typeassert on nightly.