### PR TITLE
Print max RSS in red if a worker is to be killed

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,7 +114,7 @@ The test runner provides real-time output showing:
 - Execution time
 - GC time and percentage
 - Memory allocation
-- RSS (Resident Set Size) memory usage
+- RSS (Resident Set Size) memory usage, shown in red once it exceeds the RSS threshold and the worker will be restarted
 
 ### Graceful Interruption
 

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -166,9 +166,10 @@ struct TestIOContext
     percent_align::Int
     alloc_align::Int
     rss_align::Int
+    max_worker_rss::Int
 end
 
-function test_IOContext(::Type{<:AbstractTestRecord}, stdout::IO, stderr::IO, lock::ReentrantLock, name_align::Int, verbose::Bool)
+function test_IOContext(::Type{<:AbstractTestRecord}, stdout::IO, stderr::IO, lock::ReentrantLock, name_align::Int, verbose::Bool, max_worker_rss::Int)
     elapsed_align = textwidth("time (s)")
     compile_align = textwidth("Compile")
     gc_align = textwidth("GC (s)")
@@ -180,7 +181,7 @@ function test_IOContext(::Type{<:AbstractTestRecord}, stdout::IO, stderr::IO, lo
 
     return TestIOContext(
         stdout, stderr, color, verbose, lock, name_align, elapsed_align, compile_align, gc_align, percent_align,
-        alloc_align, rss_align
+        alloc_align, rss_align, max_worker_rss
     )
 end
 
@@ -250,8 +251,12 @@ function print_test_finished(record::AbstractTestRecord, wrkr, test, ctx::TestIO
         alloc_str = @sprintf("%5.2f", base.bytes / 2^20)
         printstyled(ctx.stdout, lpad(alloc_str, ctx.alloc_align, " "), " │ ", color = :white)
 
-        rss_str = @sprintf("%5.2f", memory_usage(record) / 2^20)
-        printstyled(ctx.stdout, lpad(rss_str, ctx.rss_align, " "), " │\n", color = :white)
+        mem_use = memory_usage(record)
+        mem_color = mem_use > ctx.max_worker_rss ? :red : :white
+        rss_str = @sprintf("%5.2f", mem_use / 2^20)
+        printstyled(ctx.stdout, lpad(rss_str, ctx.rss_align, " "), color = mem_color)
+
+        printstyled(ctx.stdout, " │\n", color = :white)
 
         flush(ctx.stdout)
     finally
@@ -1037,7 +1042,7 @@ function _runtests(mod::Module, args::ParsedArgs;
         stderr.lock = print_lock
     end
 
-    io_ctx = test_IOContext(RecordType, stdout, stderr, print_lock, name_align, !isnothing(args.verbose))
+    io_ctx = test_IOContext(RecordType, stdout, stderr, print_lock, name_align, !isnothing(args.verbose), max_worker_rss)
     print_header(RecordType, io_ctx, testgroupheader, workerheader)
 
     status_lines_visible = Ref(0)


### PR DESCRIPTION
I've been finding myself wanting a more obvious way to tell if a worker was killed or not. Having RSS show up red seems like a good way to indicate that the threshold was reached and therefore the worker will be stopped.

Passing the info as IO context makes this non-breaking for custom TestRecords

Example:
<img width="979" height="74" alt="image" src="https://github.com/user-attachments/assets/09f98cfe-4534-464a-8db5-a60fbcc509dc" />
<img width="970" height="70" alt="image" src="https://github.com/user-attachments/assets/39c4799f-721e-45e4-bbb8-cc8f839b36cf" />
