### PR TITLE
Highlight terminated runners in yellow instead of red

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,7 +114,7 @@ The test runner provides real-time output showing:
 - Execution time
 - GC time and percentage
 - Memory allocation
-- RSS (Resident Set Size) memory usage, shown in red once it exceeds the RSS threshold and the worker will be restarted
+- RSS (Resident Set Size) memory usage, shown in yellow once it exceeds the RSS threshold and the worker will be restarted
 
 ### Graceful Interruption
 

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -252,7 +252,7 @@ function print_test_finished(record::AbstractTestRecord, wrkr, test, ctx::TestIO
         printstyled(ctx.stdout, lpad(alloc_str, ctx.alloc_align, " "), " │ ", color = :white)
 
         mem_use = memory_usage(record)
-        mem_color = mem_use > ctx.max_worker_rss ? :red : :white
+        mem_color = mem_use > ctx.max_worker_rss ? :yellow : :white
         rss_str = @sprintf("%5.2f", mem_use / 2^20)
         printstyled(ctx.stdout, lpad(rss_str, ctx.rss_align, " "), color = mem_color)
 


### PR DESCRIPTION
Ref: https://github.com/JuliaTesting/ParallelTestRunner.jl/pull/151#issuecomment-5152835289.  I'm open to different colour suggestions, I simply found the red a bit too alarming (there's nothing _wrong_, "just" a worker being terminated)