### PR TITLE
[tests] Remove debug printing of test output

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1347,7 +1347,7 @@ end
             serial
         )
 
-        str = String(take!(io)); print(str)
+        str = String(take!(io))
         @test contains(str, "SUCCESS")
 
         # create a mapping of test names to the character offset of their start times (lower is earlier)


### PR DESCRIPTION
I forgot to remove the print statement in the tests before committing in #138