### PR TITLE
Improve docs about relative paths

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -291,7 +291,7 @@ function jltest {
 1. **Handle platform differences**: Use conditional logic in your test suite setup to handle platform-specific tests:
 
    ```julia
-   testsuite = find_tests(pwd())
+   testsuite = find_tests(@__DIR__)
    if Sys.iswindows()
        delete!(testsuite, "unix_specific_test")
    end

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -51,7 +51,7 @@ using MyPackage
 
 # Start with autodiscovered tests
 cd(test_dir) do # hide
-testsuite = find_tests(pwd())
+testsuite = find_tests(@__DIR__)
 
 # Parse arguments
 args = parse_args(ARGS)

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -27,10 +27,10 @@ using MyPackage
 # Manually define your test suite
 testsuite = Dict(
     "basic" => quote
-        include("basic.jl")
+        include(joinpath(@__DIR__, "basic.jl"))
     end,
     "advanced" => quote
-        include("advanced.jl")
+        include(joinpath(@__DIR__, "advanced.jl"))
         @test 40 + 2 ≈ 42
     end
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,8 +59,11 @@ Pkg.test("MyPackage")
 You can pass various options to the `runtests.jl` script to control test execution:
 
 ```bash
-julia --project test/runtests.jl [OPTIONS] [TESTS...]
+julia --project runtests.jl [OPTIONS] [TESTS...]
 ```
+
+!!! note
+    When using relative paths in `runtests.jl`, remember to run the script in the correct directory.
 
 ### Available Options
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,11 +59,8 @@ Pkg.test("MyPackage")
 You can pass various options to the `runtests.jl` script to control test execution:
 
 ```bash
-julia --project runtests.jl [OPTIONS] [TESTS...]
+julia --project test/runtests.jl [OPTIONS] [TESTS...]
 ```
-
-!!! note
-    When using relative paths in `runtests.jl`, remember to run the script in the correct directory.
 
 ### Available Options
 

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -978,7 +978,7 @@ Customize the test suite
 using ParallelTestRunner
 using MyPackage
 
-testsuite = find_tests(pwd())
+testsuite = find_tests(@__DIR__)
 args = parse_args(ARGS)
 if filter_tests!(testsuite, args)
     # Remove a specific test


### PR DESCRIPTION
I'm trying to use this package after attending today’s talk at JuliaCon and ran into a minor issue caused by loading files via relative paths. While this probably was totally my own fault, I think that this change might prevent others from having the same problem.

Basically the issue was that when using `testsuite = find_tests(pwd())`, one can't simply run the `runtests.jl` script from the base directory, since this will include all `.jl` files, even those in `src`.