### PR TITLE
Improve max rss heuristic for lower memory macOS devices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParallelTestRunner"
 uuid = "d3525ed8-44d0-4b2c-a655-542cee43accc"
-version = "2.8.1"
+version = "2.8.2"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
 
 [deps]

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -72,9 +72,9 @@ function get_max_worker_rss()
     elseif Sys.WORD_SIZE == 64
         totalmem = Sys.total_memory()
         if Sys.isapple()
-            if totalmem <= 8*2^30
+            if totalmem <= 8*Int64(2)^30
                 2000
-            elseif totalmem <= 16*2^30
+            elseif totalmem <= 16*Int64(2)^30
                 2500
             else
                 3800

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -63,12 +63,27 @@ worker_id(wrkr::PTRWorker) = wrkr.id
 Malt.isrunning(wrkr::PTRWorker) = Malt.isrunning(wrkr.w)
 Malt.stop(wrkr::PTRWorker) = Malt.stop(wrkr.w)
 
-#Always set the max rss so that if tests add large global variables (which they do) we don't make the GC's life too hard
+# Always set the max rss so that if tests add large global variables
+#  (which they do) we don't make the GC's life too hard. Apple's memory
+#  management makes setting this value more complicated than it should
 function get_max_worker_rss()
     mb = if haskey(ENV, "JULIA_TEST_MAXRSS_MB")
         parse(Int, ENV["JULIA_TEST_MAXRSS_MB"])
     elseif Sys.WORD_SIZE == 64
-        Sys.total_memory() > 8*Int64(2)^30 ? 3800 : 3000
+        totalmem = Sys.total_memory()
+        if Sys.isapple()
+            if totalmem <= 8*2^30
+                2000
+            elseif totalmem <= 16*2^30
+                2500
+            else
+                3800
+            end
+        elseif totalmem > 8*Int64(2)^30
+            3800
+        else # Low memory not on macOS
+            3000
+        end
     else
         # Assume that we only have 3.5GB available to a single process, and that a single
         # test can take up to 2GB of RSS.  This means that we should instruct the test


### PR DESCRIPTION
This is the current heuristic in Metal.jl to prevent thrashing in CI, and experimenting with it in the LinearAlgebra CI seems to have cut 2-worker runs from 70 minutes (10 minutes slower than 1 worker runs) down to 34 minutes (25 minutes faster than 1 worker runs)