### PR TITLE
ETA estimate improvements

### DIFF
--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1239,21 +1239,28 @@ function _runtests(mod::Module, args::ParsedArgs;
             est_per_test = μ + 0.5σ
 
             est_remaining = 0.0
+            # a single long test can't be split across workers, so the longest
+            # remaining test is a lower bound on the ETA
+            longest_remaining = 0.0
             ## currently-running
             for (test, start_time) in running_snapshot
                 elapsed = time() - start_time
                 duration = get(historical_durations, test, est_per_test)
-                est_remaining += max(0.0, duration - elapsed)
+                remaining = max(0.0, duration - elapsed)
+                est_remaining += remaining
+                longest_remaining = max(longest_remaining, remaining)
             end
             ## yet-to-run
             for test in tests
                 haskey(running_snapshot, test) && continue
                 # Test is in any completed test
                 any(r -> test == r.test, results_snapshot) && continue
-                est_remaining += get(historical_durations, test, est_per_test)
+                duration = get(historical_durations, test, est_per_test)
+                est_remaining += duration
+                longest_remaining = max(longest_remaining, duration)
             end
 
-            eta_sec = est_remaining / jobs
+            eta_sec = max(est_remaining / jobs, longest_remaining)
             eta_mins = round(Int, eta_sec / 60)
             line3 *= " │ ETA: ~$eta_mins min"
         end

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1243,21 +1243,18 @@ function _runtests(mod::Module, args::ParsedArgs;
             # a single long test can't be split across workers, so the longest
             # remaining test is a lower bound on the ETA
             longest_remaining = 0.0
-            ## currently-running
-            for (test, start_time) in running_snapshot
-                elapsed = time() - start_time
+            now = time()
+            for test in tests
                 duration = get(historical_durations, test, est_per_test)
-                remaining = max(0.0, duration - elapsed)
+                remaining = if haskey(running_snapshot, test)
+                    max(0.0, duration - (now - running_snapshot[test]))
+                elseif test in completed_names
+                    continue
+                else
+                    duration
+                end
                 est_remaining += remaining
                 longest_remaining = max(longest_remaining, remaining)
-            end
-            ## yet-to-run
-            for test in tests
-                haskey(running_snapshot, test) && continue
-                test in completed_names && continue
-                duration = get(historical_durations, test, est_per_test)
-                est_remaining += duration
-                longest_remaining = max(longest_remaining, duration)
             end
 
             eta_sec = max(est_remaining / jobs, longest_remaining)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1214,6 +1214,7 @@ function _runtests(mod::Module, args::ParsedArgs;
         isempty(running_snapshot) && return
         results_snapshot = @lock results copy(results[])
         completed = length(results_snapshot)
+        completed_names = Set(r.test for r in results_snapshot)
         total = length(tests)
 
         # line 1: empty line
@@ -1253,8 +1254,7 @@ function _runtests(mod::Module, args::ParsedArgs;
             ## yet-to-run
             for test in tests
                 haskey(running_snapshot, test) && continue
-                # Test is in any completed test
-                any(r -> test == r.test, results_snapshot) && continue
+                test in completed_names && continue
                 duration = get(historical_durations, test, est_per_test)
                 est_remaining += duration
                 longest_remaining = max(longest_remaining, duration)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1239,9 +1239,8 @@ function _runtests(mod::Module, args::ParsedArgs;
             σ = length(durations_done) > 1 ? std(durations_done) : 0.0
             est_per_test = μ + 0.5σ
 
-            est_remaining = 0.0
-            # a single long test can't be split across workers, so the longest
-            # remaining test is a lower bound on the ETA
+            parallel_remaining = 0.0
+            serial_remaining = 0.0
             longest_remaining = 0.0
             now = time()
             for test in tests
@@ -1253,11 +1252,15 @@ function _runtests(mod::Module, args::ParsedArgs;
                 else
                     duration
                 end
-                est_remaining += remaining
+                if test in serial_tests
+                    serial_remaining += remaining
+                else
+                    parallel_remaining += remaining
+                end
                 longest_remaining = max(longest_remaining, remaining)
             end
 
-            eta_sec = max(est_remaining / jobs, longest_remaining)
+            eta_sec = max(serial_remaining + parallel_remaining / jobs, longest_remaining)
             eta_mins = round(Int, eta_sec / 60)
             line3 *= " │ ETA: ~$eta_mins min"
         end


### PR DESCRIPTION
Each commit is self-contained.

This PR (in order of impact):
- Considers serial tests for ETA estimation
- Considers the longest remaining test
- Deduplicated some logic by combining the currently-running and the not-started loops into one. (I'm open to reversing this if it hinders clarity)
- Removes an unnecessary O(n^2) bit of code (probably insignificant but the fix was simple)