### PR TITLE
Include historical information with `--list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ julia> ParallelTestRunner.runtests(ParallelTestRunner, ["--help"])
 Usage: runtests.jl [--help] [--list] [--jobs=N] [TESTS...]
 
    --help             Show this text.
-   --list             List all available tests.
+   --list             List available tests alphabetically.
    --verbose          Print more information during testing.
    --quickfail        Fail the entire run as soon as a single test errored.
    --jobs=N           Launch `N` processes to perform tests.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,7 +65,8 @@ julia --project test/runtests.jl [OPTIONS] [TESTS...]
 ### Available Options
 
 - `--help`: Show usage information and exit
-- `--list`: List all available test files and exit
+- `--list`: List all available tests alphabetically and exit. Each entry shows the
+  test's historical duration, if known, and is printed in red if its last run failed.
 - `--verbose`: Print more detailed information during test execution (including start times for each test)
 - `--quickfail`: Stop the entire test run as soon as any test fails
 - `--jobs=N`: Use `N` worker processes (default: based on CPU threads and available memory)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -66,7 +66,7 @@ julia --project test/runtests.jl [OPTIONS] [TESTS...]
 
 - `--help`: Show usage information and exit
 - `--list`: List all available tests alphabetically and exit. Each entry shows the
-  test's historical duration, if known, and is printed in red if its last run failed.
+  test's historical duration, if known, and is marked with `×` and printed in red if its last run failed.
 - `--verbose`: Print more detailed information during test execution (including start times for each test)
 - `--quickfail`: Stop the entire test run as soon as any test fails
 - `--jobs=N`: Use `N` worker processes (default: based on CPU threads and available memory)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -949,7 +949,7 @@ Several keyword arguments are also supported:
 
 - `--help`: Show usage information and exit
 - `--list`: List all available tests alphabetically and exit. Each entry shows the
-  test's historical duration, if known, and is printed in red if its last run failed.
+  test's historical duration, if known, and is marked with `×` and printed in red if its last run failed.
 - `--verbose`: Print more detailed information during test execution
 - `--quickfail`: Stop the entire test run as soon as any test fails
 - `--jobs=N`: Use N worker processes (default: based on CPU threads and available memory)
@@ -1066,8 +1066,10 @@ function runtests(mod::Module, args::ParsedArgs;
         duration_align = isempty(duration_strs) ? 0 : maximum(textwidth, values(duration_strs))
         println(stdout, "Available tests:")
         for test in sorted_tests
-            line = rstrip(" - $(rpad(test, name_align))  $(lpad(duration_strs[test], duration_align))")
-            face = test in historical_failures ? :ptr_error : :ptr_default
+            failed = test in historical_failures
+            bullet = failed ? "×" : "-"
+            face = failed ? :ptr_error : :ptr_default
+            line = rstrip(" $bullet $(rpad(test, name_align))  $(lpad(duration_strs[test], duration_align))")
             println(stdout, styled"{$face:$line}")
         end
         exit(0)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1055,9 +1055,14 @@ function runtests(mod::Module, args::ParsedArgs;
 
     # list tests, if requested
     if args.list !== nothing
+        historical_durations, historical_failures = load_test_history(mod)
         println(stdout, "Available tests:")
         for test in sort(collect(keys(testsuite)))
-            println(stdout, " - $test")
+            line = " - $test"
+            duration = get(historical_durations, test, nothing)
+            duration !== nothing && (line *= @sprintf(" (%.2fs)", duration))
+            test in historical_failures && (line *= " [failed]")
+            println(stdout, line)
         end
         exit(0)
     end

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1056,13 +1056,18 @@ function runtests(mod::Module, args::ParsedArgs;
     # list tests, if requested
     if args.list !== nothing
         historical_durations, historical_failures = load_test_history(mod)
+        sorted_tests = sort(collect(keys(testsuite)))
+        name_align = isempty(sorted_tests) ? 0 : maximum(textwidth, sorted_tests)
+        duration_strs = Dict(
+            test => (haskey(historical_durations, test) ? @sprintf("(%.2fs)", historical_durations[test]) : "")
+            for test in sorted_tests
+        )
+        duration_align = isempty(duration_strs) ? 0 : maximum(textwidth, values(duration_strs))
         println(stdout, "Available tests:")
-        for test in sort(collect(keys(testsuite)))
-            line = " - $test"
-            duration = get(historical_durations, test, nothing)
-            duration !== nothing && (line *= @sprintf(" (%.2fs)", duration))
-            test in historical_failures && (line *= " [failed]")
-            println(stdout, line)
+        for test in sorted_tests
+            line = rstrip(" - $(rpad(test, name_align))  $(lpad(duration_strs[test], duration_align))")
+            face = test in historical_failures ? :ptr_error : :ptr_default
+            println(stdout, styled"{$face:$line}")
         end
         exit(0)
     end

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -768,7 +768,7 @@ function parse_args(args; custom::Array{String} = String[])
             Usage: runtests.jl [--help] [--list] [--jobs=N] [TESTS...]
 
                --help             Show this text.
-               --list             List all available tests.
+               --list             List available tests alphabetically.
                --verbose          Print more information during testing.
                --quickfail        Fail the entire run as soon as a single test errored.
                --jobs=N           Launch `N` processes to perform tests."""
@@ -948,7 +948,8 @@ Several keyword arguments are also supported:
 ## Command Line Options
 
 - `--help`: Show usage information and exit
-- `--list`: List all available test files and exit
+- `--list`: List all available tests alphabetically and exit. Each entry shows the
+  test's historical duration, if known, and is printed in red if its last run failed.
 - `--verbose`: Print more detailed information during test execution
 - `--quickfail`: Stop the entire test run as soon as any test fails
 - `--jobs=N`: Use N worker processes (default: based on CPU threads and available memory)

--- a/src/ParallelTestRunner.jl
+++ b/src/ParallelTestRunner.jl
@@ -1056,7 +1056,7 @@ function runtests(mod::Module, args::ParsedArgs;
     # list tests, if requested
     if args.list !== nothing
         println(stdout, "Available tests:")
-        for test in keys(testsuite)
+        for test in sort(collect(keys(testsuite)))
             println(stdout, " - $test")
         end
         exit(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1013,6 +1013,48 @@ end
     @test contains(str, "SUCCESS")
 end
 
+@testset "--list output" begin
+    # `--list` exits the process, so it has to run in a subprocess
+    mod = Module(:ListOutputTest)
+    history_file = ParallelTestRunner.get_history_file(mod)
+    function list_output(args)
+        code = """
+            using ParallelTestRunner
+            testsuite = Dict(name => :(@test true) for name in ("beta", "alpha", "gamma_longer"))
+            runtests(Module(:ListOutputTest), $(repr(args)); testsuite)
+            """
+        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $code`
+        split(chomp(read(cmd, String)), '\n')
+    end
+
+    rm(history_file; force=true)
+    @test list_output(["--list"]) == [
+        "Available tests:",
+        " - alpha",
+        " - beta",
+        " - gamma_longer",
+    ]
+    # positional filters are ignored
+    @test list_output(["--list", "alpha"]) == [
+        "Available tests:",
+        " - alpha",
+        " - beta",
+        " - gamma_longer",
+    ]
+
+    ParallelTestRunner.save_test_history(mod, (Dict("alpha" => 1.234, "gamma_longer" => 123.456), Set(["gamma_longer"])))
+    try
+        @test list_output(["--list"]) == [
+            "Available tests:",
+            " - alpha           (1.23s)",
+            " - beta",
+            "\e[31m × gamma_longer  (123.46s)\e[39m",
+        ]
+    finally
+        rm(history_file; force=true)
+    end
+end
+
 @testset "addworkers" begin
     workers = addworkers(2)
     @test length(workers) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1017,34 +1017,25 @@ end
     # `--list` exits the process, so it has to run in a subprocess
     mod = Module(:ListOutputTest)
     history_file = ParallelTestRunner.get_history_file(mod)
-    function list_output(args)
+    function list_output()
         code = """
             using ParallelTestRunner
             testsuite = Dict(name => :(@test true) for name in ("beta", "alpha", "gamma_longer"))
-            runtests(Module(:ListOutputTest), $(repr(args)); testsuite)
+            runtests(Module(:ListOutputTest), ["--list"]; testsuite)
             """
-        cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $code`
-        split(chomp(read(cmd, String)), '\n')
+        readlines(`$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) --color=yes -e $code`)
     end
 
     rm(history_file; force=true)
-    @test list_output(["--list"]) == [
-        "Available tests:",
-        " - alpha",
-        " - beta",
-        " - gamma_longer",
-    ]
-    # positional filters are ignored
-    @test list_output(["--list", "alpha"]) == [
-        "Available tests:",
-        " - alpha",
-        " - beta",
-        " - gamma_longer",
-    ]
+    @test list_output() == [
+            "Available tests:",
+            " - alpha",
+            " - beta",
+            " - gamma_longer"]
 
     ParallelTestRunner.save_test_history(mod, (Dict("alpha" => 1.234, "gamma_longer" => 123.456), Set(["gamma_longer"])))
     try
-        @test list_output(["--list"]) == [
+        @test list_output() == [
             "Available tests:",
             " - alpha           (1.23s)",
             " - beta",


### PR DESCRIPTION
This PR (all related to `--list`:
- Includes historical test duration if it exists
- Marks a test with "×" if its last run failed and print it red
- Sorts them alphabetically. We used to sort them and that disappeared at some point and I can't remember if it was on purpose or not so I can revert if we don't want that

Example on Metal.jl (linalg failed):
<img width="451" height="286" alt="image" src="https://github.com/user-attachments/assets/78a902db-eec2-42d4-87c2-b3aa321a3925" />